### PR TITLE
Post-op feature added for Pooling SYCL kernel

### DIFF
--- a/src/gpu/sycl/ref_pooling.cpp
+++ b/src/gpu/sycl/ref_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,6 +66,19 @@ status_t ref_pooling_fwd_t::pd_t::init_conf() {
     conf_.DH = KDH(); //K:kernel D:Dilation H:Height
     conf_.DW = KDW(); //K:kernel D:Dilation W:Weight
 
+    const auto *att = attr();
+    const auto &attr_po = att->post_ops_;
+    conf_.po_len = attr_po.len();
+    using namespace primitive_kind;
+    for (auto i = 0; i < attr_po.len(); ++i) {
+        if (attr_po.contain(binary, i)) {
+            dnnl::impl::memory_desc_t mem = attr_po.entry_[i].binary.src1_desc;
+            conf_.src1_md[i] = sycl_md_t(&mem);
+        }
+    }
+
+    conf_.post_ops = sycl_post_ops_t(attr());
+
     return status::success;
 }
 
@@ -83,8 +96,19 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         auto src = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
         auto dst = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
         auto ws = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE);
+        auto post_v0 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1);
+        auto post_v1 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(1) | DNNL_ARG_SRC_1);
+        auto post_v2 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(2) | DNNL_ARG_SRC_1);
+        auto post_v3 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(3) | DNNL_ARG_SRC_1);
+        auto post_v4 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(4) | DNNL_ARG_SRC_1);
         auto nelems_A = memory_desc_wrapper(pd()->src_md(0)).nelems();
-        pooling_fwd_kernel_vec_t pooling_fwd_kernel(pd()->conf_, src, dst, ws);
+        pooling_fwd_kernel_vec_t pooling_fwd_kernel(pd()->conf_, src, dst, ws,
+                post_v0, post_v1, post_v2, post_v3, post_v4);
 
         const int block_size = pd()->conf_.block_size;
         const int wg_size = pd()->conf_.wg_size;

--- a/src/gpu/sycl/ref_pooling.hpp
+++ b/src/gpu/sycl/ref_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include "gpu/primitive_conf.hpp"
 #include "gpu/sycl/sycl_gpu_primitive.hpp"
 #include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
 #include "gpu/sycl/sycl_primitive_conf.hpp"
 #include "gpu/sycl/sycl_q10n.hpp"
 #include "gpu/sycl/sycl_types.hpp"
@@ -61,6 +62,7 @@ struct ref_pooling_fwd_t : public sycl_gpu_primitive_t {
                                     dst_md(0)->data_type)
                             || utils::everyone_is(s32, src_md(0)->data_type,
                                     dst_md(0)->data_type))
+                    && attr()->has_default_values(sm::post_ops)
                     && attr_.set_default_formats(dst_md(0)) == status::success;
             if (!ok) return status::unimplemented;
             // TODO: extend sycl device info to check supported sub-group sizes.

--- a/src/gpu/sycl/sycl_post_ops.hpp
+++ b/src/gpu/sycl/sycl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,6 +86,46 @@ private:
     float scale_;
 };
 
+struct ref_binary_op_t {
+    ref_binary_op_t() = default;
+    ref_binary_op_t(alg_kind_t alg, memory_desc_t src1) : alg_(alg) {
+        src1_desc = &src1;
+        using namespace alg_kind;
+        assert(utils::one_of(alg_, binary_add, binary_div, binary_max,
+                binary_min, binary_mul, binary_sub, binary_ge, binary_gt,
+                binary_le, binary_lt, binary_eq, binary_ne));
+    }
+    ref_binary_op_t(const post_ops_t::entry_t::binary_t &binary)
+        : ref_binary_op_t(binary.alg, binary.src1_desc) {}
+    float compute(float s0, float s1) const { return compute(alg_, s0, s1); }
+    static float compute(alg_kind_t alg, float s0, float s1) {
+        using namespace alg_kind;
+        using namespace math;
+        float d = 0.f;
+        switch (alg) {
+            case binary_add: d = s0 + s1; break;
+            case binary_div: d = s0 / s1; break;
+            case binary_min: d = ::sycl::min(s0, s1); break;
+            case binary_max: d = ::sycl::max(s0, s1); break;
+            case binary_mul: d = s0 * s1; break;
+            case binary_sub: d = s0 - s1; break;
+            case binary_ge: d = (float)((s0 >= s1) * -1); break;
+            case binary_gt: d = (float)((s0 > s1) * -1); break;
+            case binary_le: d = (float)((s0 <= s1) * -1); break;
+            case binary_lt: d = (float)((s0 < s1) * -1); break;
+            case binary_eq: d = (float)((s0 == s1) * -1); break;
+            case binary_ne: d = (float)((s0 != s1) * -1); break;
+            default: d = ::sycl::nan(0u);
+        }
+        return d;
+    }
+    inline memory_desc_t *Get_src1_desc() const { return src1_desc; }
+
+private:
+    alg_kind_t alg_;
+    memory_desc_t *src1_desc;
+};
+
 struct sycl_post_ops_t {
     // SYCL has a limitation on total size of kernel arguments.
     // This affects number of post ops, e.g. binary post op (which is not yet
@@ -102,6 +142,7 @@ struct sycl_post_ops_t {
 
         int sum_idx = 0;
         int eltwise_idx = 0;
+        int binary_idx = 0;
 
         for (auto i = 0; i < attr_po.len(); ++i) {
             if (attr_po.contain(sum, i)) {
@@ -111,6 +152,10 @@ struct sycl_post_ops_t {
                 post_op_kinds_[i] = eltwise;
                 eltwise_post_ops_[eltwise_idx++]
                         = ref_eltwise_fwd_t(attr_po.entry_[i].eltwise);
+            } else if (attr_po.contain(binary, i)) {
+                post_op_kinds_[i] = binary;
+                binary_post_ops_[binary_idx++]
+                        = ref_binary_op_t(attr_po.entry_[i].binary);
             }
         }
         n_post_ops_ = attr_po.len();
@@ -164,15 +209,44 @@ struct sycl_post_ops_t {
         return acc;
     }
 
+    template <int width>
+    float apply(float acc, ::sycl::vec<float, width> dst) const {
+        using namespace primitive_kind;
+        if (n_post_ops_ == 0) return acc;
+
+        int binary_idx = 0;
+        int eltwise_idx = 0;
+        for (auto i = 0; i < n_post_ops_; ++i) {
+            switch (post_op_kinds_[i]) {
+                case eltwise:
+                    acc = eltwise_post_ops_[eltwise_idx++].compute(acc);
+                    break;
+                case binary:
+                    acc = binary_post_ops_[binary_idx++].compute(acc, dst[i]);
+                    break;
+                default: acc = ::sycl::nan(0u);
+            }
+        }
+        return acc;
+    }
+    inline int Get_Post_Op() const { return n_post_ops_; }
+    inline primitive_kind_t Get_Post_Op_Kind(int i) const {
+        return post_op_kinds_[i];
+    }
+    inline ref_binary_op_t Get_Binary_Post_Op(int i) const {
+        return binary_post_ops_[i];
+    }
+
 private:
     float sum_scales_[max_post_ops];
-
+    ref_binary_op_t binary_post_ops_[max_post_ops];
     ref_eltwise_fwd_t eltwise_post_ops_[max_post_ops];
     primitive_kind_t post_op_kinds_[max_post_ops];
     // Indicates the actual number of post ops.
     int n_post_ops_;
 };
 
+CHECK_SYCL_KERNEL_ARG_TYPE(ref_binary_op_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(ref_eltwise_fwd_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_post_ops_t);
 

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -45,7 +45,7 @@ struct sycl_binary_conf_t {
 
 struct sycl_pooling_conf_t {
     sycl_md_t src_md;
-
+    sycl_md_t src1_md[8];
     sycl_md_t dst_md;
     sycl_md_t ws_md;
     sycl_md_t diff_src_md;
@@ -79,10 +79,10 @@ struct sycl_pooling_conf_t {
     dim_t DW;
     dims_t dst_dims;
     int dst_ndims;
+    sycl_post_ops_t post_ops;
 };
 
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_pooling_conf_t);
-
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 
 } // namespace sycl

--- a/src/gpu/sycl/sycl_types.hpp
+++ b/src/gpu/sycl/sycl_types.hpp
@@ -133,6 +133,14 @@ struct sycl_md_t {
 #undef CHECK_AND_ASSIGN
     }
 
+    template <typename... Args>
+    dim_t off(Args... args) const {
+        //printf("inside off\n");
+        assert(sizeof...(args) == ndims());
+        dims_t pos = {args...};
+        return off_v(pos, false);
+    }
+
     dim_t off_v(const dims_t pos, bool is_pos_padded = false) const {
         dims_t pos_copy = {0};
         for (int d = 0; d < ndims(); ++d)


### PR DESCRIPTION
# Description

Post-op feature added for pooling using sycl kernel implementation


## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

