### PR TITLE
Introducing  fuse_norm_add_relu in Batch Normalization SYCL kernel

### DIFF
--- a/src/gpu/sycl/ref_batch_normalization.cpp
+++ b/src/gpu/sycl/ref_batch_normalization.cpp
@@ -59,6 +59,7 @@ status_t ref_batch_normalization_fwd_t::pd_t::init_conf() {
     conf_.save_stats = is_training();
     conf_.calculate_stats = !stats_is_src();
     conf_.fuse_norm_relu = fuse_norm_relu();
+    conf_.fuse_norm_add_relu = fuse_norm_add_relu();
     conf_.zero_dims = has_zero_dim_memory();
     conf_.is_training = is_training();
     conf_.with_relu = with_relu_post_op(is_training());
@@ -163,6 +164,7 @@ status_t ref_batch_normalization_bwd_t::pd_t::init_conf() {
 
     conf_.batch_norm_epsilon = desc()->batch_norm_epsilon;
     conf_.fuse_norm_relu = fuse_norm_relu();
+    conf_.fuse_norm_add_relu = fuse_norm_add_relu();
     conf_.calculate_diff_stats = !use_global_stats();
     conf_.alpha = alpha();
 

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -77,6 +77,7 @@ struct sycl_batch_normalization_conf_t {
     bool calculate_stats;
     bool calculate_diff_stats;
     bool fuse_norm_relu;
+    bool fuse_norm_add_relu;
     bool zero_dims;
     bool is_training;
     bool with_relu;


### PR DESCRIPTION
# Description

Introduced the functionality `fuse_norm_add_relu` for Batch Normalization primitive both forward and backward propagation implemented using sycl kernel.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

